### PR TITLE
add failing test to show problem in setup blocks

### DIFF
--- a/test/setup_test.exs
+++ b/test/setup_test.exs
@@ -9,7 +9,19 @@ defmodule SetupTest do
     context "are handled" do
       it "correctly", context do
         assert context[:foo] == "bar"
+        assert context[:baz] == nil
       end
+    end
+  end
+
+  describe "setups within blocks" do
+    setup do
+      {:ok, [baz: "qux"]}
+    end
+  
+    it "runs setup only in this block", context do
+      assert context[:foo] == "bar"
+      assert context[:baz] == "qux"
     end
   end
 end


### PR DESCRIPTION
Thanks for ExSpec. I noticed that setup blocks are run for all specs, even if setup is inside a describe. Failing spec attached, but I'm not sure how to fix.
