### PR TITLE
define `describe/2` in terms of `context/2`, rather than vice-versa

### DIFF
--- a/lib/ex_spec.ex
+++ b/lib/ex_spec.ex
@@ -49,7 +49,7 @@ defmodule ExSpec do
     end
   end
 
-  defmacro describe(message, body) do
+  defmacro context(message, body) do
     quote do
       previous_contexts = Module.get_attribute(__MODULE__, :ex_spec_contexts)
       context = %ExSpec.Context{name: unquote(message)}
@@ -61,9 +61,9 @@ defmodule ExSpec do
     end
   end
 
-  defmacro context(message, body) do
+  defmacro describe(message, body) do
     quote do
-      describe(unquote(message), unquote(body))
+      context(unquote(message), unquote(body))
     end
   end
 


### PR DESCRIPTION
This PR reverses the definitions of macros `describe/2` and `context/2`, so that `describe/2` is a passthrough to `context/2` instead of the opposite.

This allows ExSpec to be used under Elixir 1.3 by simply replacing all instances of `describe` with `context` in the test code, rather than explicitly changing to the less-elegant `ExSpec.describe`.

No other behavior is changed.
